### PR TITLE
Added functionality to support custom, local config yaml files

### DIFF
--- a/auto_slurm/config.py
+++ b/auto_slurm/config.py
@@ -1,9 +1,19 @@
+import os
+import pathlib
+import shutil
+
 from typing import Dict
 from pydantic import BaseModel, ConfigDict
 from pydantic import PositiveInt
 from pydantic import model_validator
 from typing_extensions import Self
 from typing import Optional
+from appdirs import user_config_dir, user_cache_dir
+
+# This is the absolute string path to the auto-slurm PACKAGE folder which 
+# has been installed in the Python environment. This will be the path which 
+# contains the base version of the general_config.yaml file...
+PATH: str = pathlib.Path(__file__).parent.absolute()
 
 
 class GeneralConfig(BaseModel):
@@ -43,3 +53,76 @@ class Config(BaseModel):
             ), "gpus_per_task and max_tasks cannot be set at the same time"
 
         return self
+
+
+
+class AutoSlurmConfig:
+    """
+    AutoSlurmConfig is a class that handles the configuration of the AutoSlurm application.
+    It is responsible for setting up the configuration folder including, for example, the
+    coyping of the general_config.yaml file.
+    """
+    
+    app_name: str = 'auto_slurm'
+    app_author: str = 'AIMAT'
+    
+    def __init__(self, folder_path: Optional[str] = None):
+        # "user_config_dir" will return the absolute string path to the ".config/auto-slurm" 
+        # folder on in the users home directory for Linux and MacOS. The cool thing is that it 
+        # will also work for Windows, but the path will be different...
+        self.folder_path: str = user_config_dir(
+            self.app_name, 
+            self.app_author
+        )
+        
+        # Optional overwrite for unittesting purposes
+        if folder_path is not None:
+            self.folder_path = folder_path
+        
+        # This will be the path to the "configs" subfolder in our own config folder where 
+        # the use can define local custom config files for the aslurm command.
+        self.configs_folder_path: str = os.path.join(self.folder_path, 'configs')
+    
+    def setup_if_necessary(self) -> None:
+        """
+        Checks if the .config/auto-slurm folder exists. If it does not exist, we create it and
+        copy the general_config.yaml file from the package folder to the config folder.
+        
+        :return: None
+        """
+        
+        if not os.path.exists(self.folder_path):
+            os.makedirs(self.folder_path)
+            self.setup()
+    
+    def setup(self) -> None:
+        """
+        Sets up all the necessary structure within our own .config/auto_slurm folder. This 
+        included the copying the general_config.yaml file from the package folder to the config
+        folder.
+        
+        :return: None
+        """
+        
+        # ~ copy the general config
+        # The first thing that we need to do to setup our own config folder is to copy the 
+        # general_config.yaml file from the package folder to the config folder. 
+        shutil.copy(
+            os.path.join(PATH, 'general_config.yaml'), 
+            os.path.join(self.folder_path, 'general_config.yaml')
+        )
+        
+        # ~ create the "configs" folder
+        # Additionally we want to create a "configs" folder within our own config folder 
+        # that the user can use to store their own local config files for the aslurm command.
+        # We'll configure Hydra to also look inside this folder!
+        os.makedirs(self.configs_folder_path, exist_ok=True)
+        
+        # ~ copy the "main" base config
+        # We need to copy the "main" base config file from the package folder to the configs 
+        # folder that was just created so that custom configs can inherit from it.
+        shutil.copy(
+            os.path.join(PATH, 'configs', 'main.yaml'), 
+            os.path.join(self.configs_folder_path, 'main.yaml')
+        )
+        

--- a/auto_slurm/testing.py
+++ b/auto_slurm/testing.py
@@ -1,0 +1,41 @@
+import os
+import tempfile
+from typing import Optional
+
+from auto_slurm.config import AutoSlurmConfig
+
+
+
+
+class MockAutoSlurmConfig:
+    """
+    This is a context manager that creates a temporary directory and sets up a new 
+    AutoSlurmConfig object in it. The temporary directory will be deleted when the 
+    context manager is exited. This is useful for testing purposes, as it allows 
+    to create a clean environment for each test without affecting the user's
+    configuration files.
+    """
+    
+    def __init__(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        
+        # This will hold the absolute string path to the temporary directory
+        self.temp_path: Optional[str] = None
+        # This will hold the absolute string path to the "auto_slurm" sub folder in 
+        # the temporary directory
+        self.config_path: Optional[str] = None
+        # After initialization, this will hold the AutoSlurmConfig object that will 
+        # be created in the temporary directory and which manages the configuration
+        self.config: Optional[AutoSlurmConfig] = None
+    
+    def __enter__(self) -> AutoSlurmConfig:
+        self.temp_path = self.temp_dir.__enter__()
+        self.config_path = os.path.join(self.temp_path, 'auto_slurm')
+        self.config = AutoSlurmConfig(folder_path=self.config_path)
+        self.config.setup_if_necessary()
+        
+        return self.config
+    
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.temp_dir.__exit__(exc_type, exc_value, traceback)
+        

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,11 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.7"
-dependencies = ["hydra-core", "pydantic>=2.5.3"]
+dependencies = [
+    "hydra-core", 
+    "pydantic>=2.5.3", 
+    "appdirs>=1.0.0,<=2.0.0"
+]
 
 [project.scripts]
 aslurm = "auto_slurm.aslurm:main"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,31 @@
+"""
+Unittests for the "auto_slurm/config.py" module
+"""
+
+import os
+import tempfile
+from auto_slurm.config import AutoSlurmConfig
+
+
+class TestAutoSlurmConfig:
+    
+    def test_setup_basically_works(self):
+        
+        with tempfile.TemporaryDirectory() as path:
+            
+            config_path = os.path.join(path, 'auto_slurm')
+            config = AutoSlurmConfig(folder_path=config_path)
+            config.setup_if_necessary()
+            
+            # Check if the folder was created
+            assert os.path.exists(config.folder_path)
+            
+            # Check if the general_config.yaml file was copied
+            assert os.path.exists(os.path.join(config.folder_path, 'general_config.yaml'))
+            
+            # Check if the configs folder was created
+            assert os.path.exists(config.configs_folder_path)
+            
+            # Check if the configs folder is empty
+            assert len(os.listdir(config.configs_folder_path)) == 1
+            

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,23 @@
+"""
+Unittests for the "auto_slurm/testing.py" module
+"""
+
+import os
+from auto_slurm.config import AutoSlurmConfig
+from auto_slurm.testing import MockAutoSlurmConfig
+
+
+class TestMockAutoSlurmConfig:
+    
+    def test_basically_works(self):
+        
+        with MockAutoSlurmConfig() as config:
+            
+            assert isinstance(config, AutoSlurmConfig)
+            
+            # The path itself should exist
+            assert os.path.exists(config.folder_path)
+            # The general config should be copied
+            assert os.path.exists(os.path.join(config.folder_path, 'general_config.yaml'))
+            # The configs folder path should exist
+            assert os.path.exists(config.configs_folder_path)


### PR DESCRIPTION
# Main Changes

The` ~/.config/auto_slurm config` folder, which also contains the `general_config.yaml ` file, is now also initialized to contain an additional `configs` subfolder. The user can add YAML config files to this folder. In the main command, Hydra will now first try to find config files from that folder, so it is also possible to locally overwrite default configs.

I mainly needed this because I want to use AutoSlurm for my local Slurm configuration, and it wouldn't make sense to permanently add a config file describing my local computer 😅 

## Other changes

- Added the `auto_slurm.config.AutoSlurmConfig` class, which manages the `~/.config` folder for the user. This is now using the `appdirs` package which automatically selects the correct config folder location for all the different operating systems.
- Added a unittest folder `tests`. To execute the unittests one can simply install pytest: `uv pip install pytest` and run it for the tests folder: `pytest ./tests/`.
- Added unittests for the `AutoSlurmConfig` functionality
