### PR TITLE
Fix sweep expansion to preserve commas inside quoted strings

### DIFF
--- a/auto_slurm/aslurm.py
+++ b/auto_slurm/aslurm.py
@@ -204,18 +204,22 @@ def split_top_level_commas(s: str):
     parts = []
     current = []
     depth = 0
+    in_quotes = False
 
     for ch in s:
-        if ch in "[{(":
-            depth += 1
-        elif ch in "]})":
-            depth -= 1
-            if depth < 0:
-                raise ValueError("Unbalanced brackets")
-        elif ch == "," and depth == 0:
-            parts.append("".join(current).strip())
-            current = []
-            continue
+        if ch == '"' and depth == 0:
+            in_quotes = not in_quotes
+        elif not in_quotes:
+            if ch in "[{(":
+                depth += 1
+            elif ch in "]})":
+                depth -= 1
+                if depth < 0:
+                    raise ValueError("Unbalanced brackets")
+            elif ch == "," and depth == 0:
+                parts.append("".join(current).strip())
+                current = []
+                continue
         current.append(ch)
 
     if depth != 0:

--- a/auto_slurm/tests.py
+++ b/auto_slurm/tests.py
@@ -74,6 +74,20 @@ class TestSlurmScript(unittest.TestCase):
         self.assertIn("CUDA_VISIBLE_DEVICES=2,3", main_contents)
         self.assertIn("CUDA_VISIBLE_DEVICES=2,3", resume_contents)
 
+    def test_expand_commands_braces_with_commas_in_values(self):
+        commands = [
+            'python train.py --features \'<{"partial_charges", "partial_charges,x", "x"}>\' --lr <{1e-3,1e-4}>'
+        ]
+        expected = [
+            'python train.py --features \'"partial_charges"\' --lr 1e-3',
+            'python train.py --features \'"partial_charges"\' --lr 1e-4',
+            'python train.py --features \'"partial_charges,x"\' --lr 1e-3',
+            'python train.py --features \'"partial_charges,x"\' --lr 1e-4',
+            'python train.py --features \'"x"\' --lr 1e-3',
+            'python train.py --features \'"x"\' --lr 1e-4',
+        ]
+        self.assertEqual(expand_commands(commands), expected)
+
     def test_expand_commands_invalid_syntax(self):
         commands = ["python train.py --lr <[0.01,0.1]> --batch_size <{32,64}>"]
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- `split_top_level_commas()` only tracked bracket depth `[{(` but ignored double-quoted strings
- This caused sweep values containing commas (e.g. `"partial_charges,x"`) to be incorrectly split, producing broken shell commands with mismatched quotes
- Added quote-awareness (`in_quotes` flag) to preserve commas inside `"..."`
- Added test case covering this scenario

## Example
```
--embedding-features '<{"partial_charges", "partial_charges,x", "x"}>'
```
**Before:** `"partial_charges,x"` was split into `"partial_charges` and `x"` (broken quotes)
**After:** `"partial_charges,x"` is preserved as a single value

## Test plan
- [x] All existing tests pass
- [x] New test `test_expand_commands_braces_with_commas_in_values` covers the fix